### PR TITLE
Switch from geebee to new image service

### DIFF
--- a/footer/main.scss
+++ b/footer/main.scss
@@ -12,8 +12,8 @@
 }
 
 .o-footer__more-from-ft .o-icons-icon--arrow-right {
-  background-image: url("https://www.ft.com/__origami/service/image/v2/images/raw/fticon:arrow-right?source=o-icons&tint=%23FFFFFF,%23FFFFFF&format=svg");
-  background-image: url("https://www.ft.com/__origami/service/image/v2/images/raw/fticon:arrow-right?source=o-icons&tint=%23FFFFFF,%23FFFFFF&format=png&width=16") \9;
+  background-image: url("https://www.ft.com/__origami/service/image/v2/images/raw/fticon:arrow-right?source=alphaville2&tint=%23FFFFFF&format=svg");
+  background-image: url("https://www.ft.com/__origami/service/image/v2/images/raw/fticon:arrow-right?source=alphaville2&tint=%23FFFFFF&format=png&width=16") \9;
   width: 16px;
   height: 16px;
   display: inline-block;

--- a/footer/main.scss
+++ b/footer/main.scss
@@ -12,8 +12,8 @@
 }
 
 .o-footer__more-from-ft .o-icons-icon--arrow-right {
-  background-image: url("https://next-geebee.ft.com/image/v1/images/raw/fticon:arrow-right?source=o-icons&tint=%23FFFFFF,%23FFFFFF&format=svg");
-  background-image: url("https://next-geebee.ft.com/image/v1/images/raw/fticon:arrow-right?source=o-icons&tint=%23FFFFFF,%23FFFFFF&format=png&width=16") \9;
+  background-image: url("https://www.ft.com/__origami/service/image/v2/images/raw/fticon:arrow-right?source=o-icons&tint=%23FFFFFF,%23FFFFFF&format=svg");
+  background-image: url("https://www.ft.com/__origami/service/image/v2/images/raw/fticon:arrow-right?source=o-icons&tint=%23FFFFFF,%23FFFFFF&format=png&width=16") \9;
   width: 16px;
   height: 16px;
   display: inline-block;


### PR DESCRIPTION
We launched the new image service 6 days ago, I'm currently going around FT projects and helping them migrate to it.

The new Image Service includes a lot of improvements:
- The application is multi-region with failover
- We use stale-on-error and stale-while-revalidate cache extensions to ensure users get stale content if the application errors or has to revalidate an image
- We serve much smaller WebP and JPEG XR images to supported browsers
- We’ve seen a reduction in file size for a large number of image requests
- We’re now serving images over H2