### PR TITLE
Amend: simplify krux page attributes

### DIFF
--- a/ads/config/prod.handlebars
+++ b/ads/config/prod.handlebars
@@ -16,9 +16,7 @@
 			{{#unless article}}
 				"attributes": {
 					"page": {
-						"key": "sections",
-						"name": "sections",
-						"values": ["{{title}}"]
+						"sections": ["{{title}}"]
 					}
 				},
 			{{/unless}}

--- a/ads/config/test.handlebars
+++ b/ads/config/test.handlebars
@@ -16,9 +16,7 @@
 			{{#unless article}}
 				"attributes": {
 					"page": {
-						"key": "sections",
-						"name": "sections",
-						"values": ["{{title}}"]
+						"sections": ["{{title}}"]
 					}
 				},
 			{{/unless}}


### PR DESCRIPTION
cc: @roland-vachter 

Had feedback from the ad ops team that the krux data for sections can be simplified. The data structure gets processed a little differently within ft.com.