### PR TITLE
Remove link in footer to Economic Calendar

### DIFF
--- a/footer/main.handlebars
+++ b/footer/main.handlebars
@@ -66,7 +66,6 @@
 											</div>
 											<div class="o-footer__matrix-column">
 
-													<a class="o-footer__matrix-link" href="http://markets.ft.com/data/world/economic-calendar" data-trackable="Economic Calendar">Economic Calendar</a>
 													<a class="o-footer__matrix-link" href="https://www.ft.com/news-feed" data-trackable="News feed">News feed</a>
 													<a class="o-footer__matrix-link" href="http://nbe.ft.com/nbe/profile.cfm?ft_site=falcon" data-trackable="Newsletters">Newsletters</a>
 													<a class="o-footer__matrix-link" href="http://markets.ft.com/research/Markets/Currencies?segid=70113" data-trackable="Currency Converter">Currency Converter</a>


### PR DESCRIPTION
The economic calendar tool has been removed from Markets Data so the link needs to be removed from the footer.