### PR TITLE
Add `data-o-comments-count` attribute

### DIFF
--- a/overlays/AlertOverlay.js
+++ b/overlays/AlertOverlay.js
@@ -1,5 +1,5 @@
 const Overlay = require('o-overlay');
-const Delegate = require('dom-delegate');
+const Delegate = require('ftdomdelegate');
 
 function AlertOverlay (title, text) {
 	if (!text) {

--- a/overlays/ConfirmOverlay.js
+++ b/overlays/ConfirmOverlay.js
@@ -1,5 +1,5 @@
 const Overlay = require('o-overlay');
-const Delegate = require('dom-delegate');
+const Delegate = require('ftdomdelegate');
 
 function ConfirmOverlay (title, text) {
 	if (!text) {

--- a/overlays/FormOverlay.js
+++ b/overlays/FormOverlay.js
@@ -1,5 +1,5 @@
 const Overlay = require('o-overlay');
-const Delegate = require('dom-delegate');
+const Delegate = require('ftdomdelegate');
 
 function serialize (form) {
 	const s = {};

--- a/share/main.handlebars
+++ b/share/main.handlebars
@@ -20,7 +20,7 @@
 
 		{{#article.comments.enabled}}
 			{{^hideCommentCount}}
-			<a href="#comments" class="article__share__comments article__share-item" data-o-component="o-comments" data-o-comments-count data-o-comments-count-config-article-id="{{article.id}}" data-o-comments-count-config-template="{count}" data-trackable="comment-count"></a>
+			<a href="#comments" class="article__share__comments article__share-item" data-o-component="o-comments" data-o-comments-count data-o-comments-config-article-id="{{article.id}}" data-o-comments-config-template="{count}" data-trackable="comment-count"></a>
 			{{/hideCommentCount}}
 		{{/article.comments.enabled}}
 	</div>

--- a/share/main.handlebars
+++ b/share/main.handlebars
@@ -20,7 +20,7 @@
 
 		{{#article.comments.enabled}}
 			{{^hideCommentCount}}
-			<a href="#comments" class="article__share__comments article__share-item" data-o-component="o-comment-count" data-o-comment-count-config-article-id="{{article.id}}" data-o-comment-count-config-template="{count}" data-trackable="comment-count"></a>
+			<a href="#comments" class="article__share__comments article__share-item" data-o-component="o-comments" data-o-comments-count data-o-comments-count-config-article-id="{{article.id}}" data-o-comments-count-config-template="{count}" data-trackable="comment-count"></a>
 			{{/hideCommentCount}}
 		{{/article.comments.enabled}}
 	</div>


### PR DESCRIPTION
In order to differentiate when comments should be rendered vs when comment count should be rendered. We've added a new attribute `data-o-comments-count` to any instances of comment count.

Related to: https://github.com/Financial-Times/alphaville-longroom/pull/19