### PR TITLE
ADSDEV-83 Remove Krux from oAds declarative config

### DIFF
--- a/ads/config/prod.handlebars
+++ b/ads/config/prod.handlebars
@@ -11,25 +11,6 @@
 			{{^articleId}}"page": null,{{/articleId}}
 			"usePageZone": false
 		},
-		"krux": {
-			"limit": 50,
-			{{#if adsTitle}}
-				"attributes": {
-					"page": {
-						"sections": ["{{adsTitle}}"]
-					}
-				},
-			{{else}}
-				{{#unless article}}
-					"attributes": {
-						"page": {
-							"sections": ["{{title}}"]
-						}
-					},
-				{{/unless}}
-			{{/if}}
-			"id": "KHUSeE3x"
-		},
 		"collapseEmpty": "before",
 		"responsive": {
 			"extra": [1220, 0],

--- a/ads/config/test.handlebars
+++ b/ads/config/test.handlebars
@@ -11,17 +11,6 @@
 			{{^articleId}}"page": null,{{/articleId}}
 			"usePageZone": true
 		},
-		"krux": {
-			"limit": 50,
-			{{#unless article}}
-				"attributes": {
-					"page": {
-						"sections": ["{{title}}"]
-					}
-				},
-			{{/unless}}
-			"id": "IgnVxTJW"
-		},
 		"collapseEmpty": "before",
 		"responsive": {
 			"extra": [1220, 0],

--- a/bower.json
+++ b/bower.json
@@ -11,7 +11,7 @@
     "main.scss"
   ],
   "dependencies": {
-    "o-ads": "^10.0.4",
+    "o-ads": "^13.0.0",
     "o-grid": "^4.0.0",
     "o-buttons": "^5.0.0",
     "o-footer": "^6.0.0",

--- a/permutive/index.js
+++ b/permutive/index.js
@@ -1,5 +1,5 @@
-const oPermutive = require('o-permutive');
-const oAds = require('o-ads');
+import oPermutive from 'o-permutive';
+import oAds from 'o-ads';
 
 /*
  * Permutive's project ID and API Key


### PR DESCRIPTION
See Jira https://jira.ft.com/browse/ADSDEV-83

The Ads team is switching from Krux to Permutive for user segments.

Avoid loading Krux script into the DOM by removing Krux from oAds declarative configuration.