### PR TITLE
Use `o-comments` v6 when `useCoralTalk` is true

### DIFF
--- a/share/main.handlebars
+++ b/share/main.handlebars
@@ -20,7 +20,24 @@
 
 		{{#article.comments.enabled}}
 			{{^hideCommentCount}}
-			<a href="#comments" class="article__share__comments article__share-item" data-o-component="o-comments" data-o-comments-count data-o-comments-config-article-id="{{article.id}}" data-o-comments-config-template="{count}" data-trackable="comment-count"></a>
+				{{#if useCoralTalk}}
+					<a href="#comments"
+						class="o-comments article__share__comments article__share-item"
+						data-o-component="o-comments"
+						data-o-comments-article-id="{{article.id}}"
+						data-o-comments-count="true"
+						data-trackable="comment-count">
+					</a>
+				{{else}}
+					<a href="#comments"
+						class="article__share__comments article__share-item"
+						data-o-component="o-comments"
+						data-o-comments-count
+						data-o-comments-config-article-id="{{article.id}}"
+						data-o-comments-config-template="{count}"
+						data-trackable="comment-count">
+					</a>
+				{{/if}}
 			{{/hideCommentCount}}
 		{{/article.comments.enabled}}
 	</div>


### PR DESCRIPTION
`alphaville-ui` is used by `alphaville-blogs` and provides the comment
count markup for the Alphaville article page.

Related to: https://github.com/Financial-Times/alphaville-blogs/pull/32