### PR TITLE
ADSDEV-226 o-permutive.identifyUser requires an array argument

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -28,7 +28,7 @@
     "o-teaser": "^2.0.0",
     "o-forms": "^5.0.0",
     "o-cookie-message": "^4.5.2",
-    "o-permutive": "^1.0.4"
+    "o-permutive": "^1.0.5"
   },
   "license": "MIT",
   "ignore": [

--- a/permutive/index.js
+++ b/permutive/index.js
@@ -44,9 +44,9 @@ const getUser = () => {
  * Retrieve content from Ads v2
  */
 const getContent = (contentId) => {
-	if (contentId) {
-		return Promise.resolve();
-	}
+	// Skip call to Ads API if no `contentId` provided. e.g., homepage
+	if (!contentId) { return Promise.resolve(); }
+
 	return oAds.api.getPageData(adsApiEndpoints.content(contentId), 250)
 		.catch((error) => {
 			console.warn('oPermutive: Could not set page metadata', error);

--- a/permutive/index.js
+++ b/permutive/index.js
@@ -44,10 +44,12 @@ const getUser = () => {
  * Retrieve content from Ads v2
  */
 const getContent = (contentId) => {
-	return oAds.api.getPageData(adsApiEndpoints.content(contentId), 250)
-		.catch((error) => {
-			console.warn('oPermutive: Could not set page metadata', error);
-		});
+	if (contentId) {
+		return oAds.api.getPageData(adsApiEndpoints.content(contentId), 250)
+			.catch((error) => {
+				console.warn('oPermutive: Could not set page metadata', error);
+			});
+	}
 };
 
 /*

--- a/permutive/index.js
+++ b/permutive/index.js
@@ -55,10 +55,16 @@ const getContent = (contentId) => {
  */
 const identifyUser = (user) => {
 	if (user) {
-		oPermutive.identifyUser({
-			guid: user.uuid,
-			spoorID: user.spoorId,
-		});
+		oPermutive.identifyUser([
+			{
+				id: user.spoorId,
+				tag: 'SporeID',
+			},
+			{
+				id: user.uuid,
+				tag: 'GUID',
+			}
+		]);
 		return user;
 	}
 };

--- a/permutive/index.js
+++ b/permutive/index.js
@@ -94,10 +94,14 @@ const setPageMetaData = (content, user) => {
 			industry: user.industry && user.industry.code,
 			responsibility: user.responsibility && user.responsibility.code,
 			position: user.position && user.position.code,
+			subscriptionLevel: user.subscriptionLevel,
+			loggedIn: user.loggedInStatus,
+			indb2b: user.hui.indb2b,
+			gender: user.hui.gender,
 		};
 	}
 
-	oPermutive.setPageMetaData(pageMetaData);
+	oPermutive.setPageMetaData({ page: pageMetaData });
 };
 
 const setUser = () =>

--- a/permutive/index.js
+++ b/permutive/index.js
@@ -99,8 +99,8 @@ const setPageMetaData = (content, user) => {
 			position: user.position && user.position.code,
 			subscriptionLevel: user.subscriptionLevel,
 			loggedIn: (!!user.loggedInStatus).toString(),
-			indb2b: user.hui.indb2b,
-			gender: user.hui.gender,
+			indb2b: user.hui && user.hui.indb2b,
+			gender: user.hui && user.hui.gender,
 		};
 	}
 

--- a/permutive/index.js
+++ b/permutive/index.js
@@ -95,7 +95,7 @@ const setPageMetaData = (content, user) => {
 			responsibility: user.responsibility && user.responsibility.code,
 			position: user.position && user.position.code,
 			subscriptionLevel: user.subscriptionLevel,
-			loggedIn: user.loggedInStatus,
+			loggedIn: (!!user.loggedInStatus).toString(),
 			indb2b: user.hui.indb2b,
 			gender: user.hui.gender,
 		};

--- a/permutive/index.js
+++ b/permutive/index.js
@@ -45,11 +45,12 @@ const getUser = () => {
  */
 const getContent = (contentId) => {
 	if (contentId) {
-		return oAds.api.getPageData(adsApiEndpoints.content(contentId), 250)
-			.catch((error) => {
-				console.warn('oPermutive: Could not set page metadata', error);
-			});
+		return Promise.resolve();
 	}
+	return oAds.api.getPageData(adsApiEndpoints.content(contentId), 250)
+		.catch((error) => {
+			console.warn('oPermutive: Could not set page metadata', error);
+		});
 };
 
 /*

--- a/permutive/index.js
+++ b/permutive/index.js
@@ -79,7 +79,7 @@ const setPageMetaData = (content, user) => {
 		pageMetaData.article = {
 			id: content.uuid,
 			// title,
-			// type,
+			type: content.genre && content.genre instanceof Array && content.genre[0],
 			organisations: content.organisation,
 			people: content.person,
 			categories: content.categories,


### PR DESCRIPTION
This is part of Jira ticket [#226 Alphaville - Pageview event not passed to Permutive](https://financialtimes.atlassian.net/browse/ADSDEV-226?atlOrigin=eyJpIjoiY2I4ZGE3MzY1MGZlNDZiY2ExMWM4NTg5Y2ZlOWM5MzQiLCJwIjoiaiJ9ADSDEV-226)

See also related PRs: [alphaville-longroom #35](https://github.com/Financial-Times/alphaville-longroom/pull/35), [alphaville-blogs #36](https://github.com/Financial-Times/alphaville-blogs/pull/36)

## Description
`Permutive` is not working properly on Alphaville, specifically it is not firing the `PageView` event from Alphaville.

## Changes
* **Pass the _user_ to `o-permutive.identifyUser()`.**
Since [v.1.0.4](https://github.com/Financial-Times/o-permutive/tree/v1.0.4) `o-permutive`'s method `identifyUser()` requires an argument array of `{id, tag}` objects.

* **Pass the _page_ metadata to o-permutive.setPageMetaData**
`o-permutive`'s method 'setPageMetaData()' requires an object with a root data point `page`.
Added the `article`'s datapoints: `type` (genre).
Added the `users`'s datapoints: `loggedIn`, `subscriptionLevel`, `indb2b`, `gender`.