### PR TITLE
Don't render comment count on Longroom article

### DIFF
--- a/share/main.handlebars
+++ b/share/main.handlebars
@@ -20,24 +20,26 @@
 
 		{{#article.comments.enabled}}
 			{{^hideCommentCount}}
-				{{#if useCoralTalk}}
-					<a href="#comments"
-						class="o-comments article__share__comments article__share-item"
-						data-o-component="o-comments"
-						data-o-comments-article-id="{{article.id}}"
-						data-o-comments-count="true"
-						data-trackable="comment-count">
-					</a>
-				{{else}}
-					<a href="#comments"
-						class="article__share__comments article__share-item"
-						data-o-component="o-comments"
-						data-o-comments-count
-						data-o-comments-config-article-id="{{article.id}}"
-						data-o-comments-config-template="{count}"
-						data-trackable="comment-count">
-					</a>
-				{{/if}}
+				{{#unless longroomCommentCountDisabled}}
+					{{#if useCoralTalk}}
+						<a href="#comments"
+							class="o-comments article__share__comments article__share-item"
+							data-o-component="o-comments"
+							data-o-comments-article-id="{{article.id}}"
+							data-o-comments-count="true"
+							data-trackable="comment-count">
+						</a>
+					{{else}}
+						<a href="#comments"
+							class="article__share__comments article__share-item"
+							data-o-component="o-comments"
+							data-o-comments-count
+							data-o-comments-config-article-id="{{article.id}}"
+							data-o-comments-config-template="{count}"
+							data-trackable="comment-count">
+						</a>
+					{{/if}}
+				{{/unless}}
 			{{/hideCommentCount}}
 		{{/article.comments.enabled}}
 	</div>


### PR DESCRIPTION
We had some issues with rendering the comment count on the Longroom
article page. After some discussions we decided to remove it altogether
because it doesn't add a lot of value to the page as the comment stream
is right below it.

Related to PR: https://github.com/Financial-Times/alphaville-longroom/pull/39