### PR TITLE
Bump o-forms to v6, and o-teaser to v3

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -25,8 +25,8 @@
     "o-viewport": "^3.0.0",
     "o-overlay": "^2.0.0",
     "o-share": "^6.0.0",
-    "o-teaser": "^2.0.0",
-    "o-forms": "^5.0.0",
+    "o-teaser": "^3.0.0",
+    "o-forms": "^6.0.0",
     "o-cookie-message": "^4.5.2",
     "o-permutive": "^1.0.5"
   },


### PR DESCRIPTION
Right now, anything that uses this ui library is producing lots of build
warnings with is polluting the dev environment. These errors are comming
from old versions of o-forms and o-teaser, which this lib use.

This commit bumps both of those versions. Though both of them are major
versions, there is no other work required as they are both only major
because of a dependency chain problem which does not affect this library