### PR TITLE
Remove Livefyre comment count

### DIFF
--- a/share/main.handlebars
+++ b/share/main.handlebars
@@ -20,24 +20,13 @@
 
 		{{#article.comments.enabled}}
 			{{^hideCommentCount}}
-				{{#if useCoralTalk}}
-					<a href="#comments"
-						class="o-comments article__share__comments article__share-item"
-						data-o-component="o-comments"
-						data-o-comments-article-id="{{article.id}}"
-						data-o-comments-count="true"
-						data-trackable="comment-count">
-					</a>
-				{{else}}
-					<a href="#comments"
-						class="article__share__comments article__share-item"
-						data-o-component="o-comments"
-						data-o-comments-count
-						data-o-comments-config-article-id="{{article.id}}"
-						data-o-comments-config-template="{count}"
-						data-trackable="comment-count">
-					</a>
-				{{/if}}
+				<a href="#comments"
+					class="o-comments article__share__comments article__share-item"
+					data-o-component="o-comments"
+					data-o-comments-article-id="{{article.id}}"
+					data-o-comments-count="true"
+					data-trackable="comment-count">
+				</a>
 			{{/hideCommentCount}}
 		{{/article.comments.enabled}}
 	</div>


### PR DESCRIPTION
Once Coral migration is complete, we can merge this PR to remove
Livefyre comment counts.

This app provides the comment counts for Alphaville Blogs article pages.

Related to: https://github.com/Financial-Times/alphaville-blogs/pull/44