### PR TITLE
Upgrade to latest origami packages

### DIFF
--- a/ads/main.scss
+++ b/ads/main.scss
@@ -5,7 +5,7 @@
 		display: block;
 		padding: 10px 0;
 		line-height: 0;
-		background-color: oColorsGetPaletteColor('black-20');
+		background-color: oColorsByName('black-20');
 	}
 }
 

--- a/article-list/main.scss
+++ b/article-list/main.scss
@@ -11,7 +11,7 @@
 		.alphaville-list-time-date {
 			font-size: 16px;
 			line-height: 22px;
-			color: oColorsGetPaletteColor('black-40');
+			color: oColorsByName('black-40');
 			font-weight: 600;
 			text-transform: uppercase;
 		}
@@ -25,11 +25,11 @@
 
 	.alphaville-ad-stream {
 		padding: 20px 0;
-		border-bottom: 1px solid oColorsGetPaletteColor('black-20');
+		border-bottom: 1px solid oColorsByName('black-20');
 	}
 
 	.alphaville-card-container {
-		border-bottom: 1px solid oColorsGetPaletteColor('black-20');
+		border-bottom: 1px solid oColorsByName('black-20');
 		padding: 10px 0 20px;
 
 		&:after {

--- a/barrier/main.handlebars
+++ b/barrier/main.handlebars
@@ -7,7 +7,7 @@
     {{#if register}}
         <a class="o-buttons o-buttons--big o-buttons--primary" role="button" href="{{register}}" data-trackable="register">Register</a>
     {{/if}}
-	<a class="o-buttons o-buttons--big" role="button" href="{{loginUrl}}" data-trackable="sign-in">{{loginText}}</a>
+	<a class="o-buttons o-buttons--secondary o-buttons--big" role="button" href="{{loginUrl}}" data-trackable="sign-in">{{loginText}}</a>
 	<p>
         {{#if subscriptions}}
             Ready to subscribe, <a class="barrier-link" href="{{subscriptions}}" data-trackable="subscription">View our subscription options</a>

--- a/bower.json
+++ b/bower.json
@@ -11,7 +11,7 @@
     "main.scss"
   ],
   "dependencies": {
-    "o-ads": "^13.0.0",
+    "o-ads": "^14.0.0",
     "o-grid": "^5.0.0",
     "o-buttons": "^6.0.0",
     "o-footer": "^7.0.0",

--- a/bower.json
+++ b/bower.json
@@ -12,23 +12,24 @@
   ],
   "dependencies": {
     "o-ads": "^13.0.0",
-    "o-grid": "^4.0.0",
-    "o-buttons": "^5.0.0",
-    "o-footer": "^6.0.0",
-    "o-header": "^7.0.0",
-    "o-colors": "^4.0.0",
-    "o-icons": "^5.0.0",
-    "o-date": "^2.5.0",
-    "o-typography": "^5.0.0",
-    "o-tracking": "^1.1.15",
-    "o-fonts": "^3.0.0",
-    "o-viewport": "^3.0.0",
-    "o-overlay": "^2.0.0",
-    "o-share": "^6.0.0",
-    "o-teaser": "^3.0.0",
-    "o-forms": "^6.0.0",
-    "o-cookie-message": "^4.5.2",
-    "o-permutive": "^1.0.5"
+    "o-grid": "^5.0.0",
+    "o-buttons": "^6.0.0",
+    "o-footer": "^7.0.0",
+    "o-header": "^8.0.0",
+    "o-colors": "^5.0.0",
+    "o-icons": "^6.0.0",
+    "o-date": "^4.0.0",
+    "o-editorial-typography": "^1.0.0",
+    "o-typography": "^6.0.0",
+    "o-tracking": "^2.0.3",
+    "o-fonts": "^4.0.0",
+    "o-viewport": "^4.0.0",
+    "o-overlay": "^3.0.0",
+    "o-share": "^7.0.0",
+    "o-teaser": "^4.0.0",
+    "o-forms": "^8.0.0",
+    "o-cookie-message": "^5.0.0",
+    "o-permutive": "^1.0.7"
   },
   "license": "MIT",
   "ignore": [
@@ -37,8 +38,5 @@
     "bower_components",
     "test",
     "tests"
-  ],
-  "resolutions": {
-    "o-viewport": "^3.0.0"
-  }
+  ]
 }

--- a/card/main.scss
+++ b/card/main.scss
@@ -92,6 +92,12 @@ $alphaville-card__color--yellow-tint3: #b35400;
 	padding: 10px 10px 0;
 	box-sizing: border-box;
 
+	& *,
+	& *:before,
+	& *:after {
+		box-sizing: inherit;
+	}
+
 	$comment-counter-color: #22757c;
 	.alphaville-card--comment-counter {
 		@include oTypographySans($scale: -2);

--- a/card/main.scss
+++ b/card/main.scss
@@ -41,7 +41,7 @@ $alphaville-card__color--yellow-tint3: #b35400;
 }
 
 .alphaville-card__tag {
-	@include oEditorialTypographyTag(null);
+	@include oEditorialTypographyTag('topic');
 	margin: 0 0 10px;
 	display: inline-block;
 }

--- a/card/main.scss
+++ b/card/main.scss
@@ -23,7 +23,7 @@ $alphaville-card__color--yellow-tint3: #b35400;
 
 .alphaville-card__heading {
 	@include oTeaserHeading();
-	@include oTypographyDisplay($scale: 4);
+	@include oTypographyDisplay($scale: 4, $include-font-family: false);
 	margin-bottom: 10px;
 }
 

--- a/card/main.scss
+++ b/card/main.scss
@@ -47,7 +47,14 @@ $alphaville-card__color--yellow-tint3: #b35400;
 }
 
 .alphaville-card__standfirst {
-	@include oEditorialTypographyStandfirst();
+	@include oTypographySans($scale: 0, $include-font-family: false);
+	color: oColorsByName('black-60');
+	margin-top: 0;
+	margin-bottom: 0;
+
+	a {
+		@include oTypographyLink();
+	}
 }
 
 .alphaville-card__standfirst-truncate--2lines {

--- a/card/main.scss
+++ b/card/main.scss
@@ -42,6 +42,7 @@ $alphaville-card__color--yellow-tint3: #b35400;
 
 .alphaville-card__tag {
 	@include oEditorialTypographyTag('topic');
+	@include oTypographySans(0);
 	margin: 0 0 10px;
 	display: inline-block;
 }
@@ -79,6 +80,7 @@ $alphaville-card__color--yellow-tint3: #b35400;
 
 .alphaville-card__timestamp {
 	@include oEditorialTypographyTimestamp();
+	@include oTypographySans(-2);
 	display: inline-block;
 }
 

--- a/card/main.scss
+++ b/card/main.scss
@@ -1,5 +1,4 @@
-$o-teaser-is-silent: false;
-@import 'o-teaser/main';
+@include oTeaser();
 
 $alphaville-card__color--pink-tint1: #ebe0d1;
 $alphaville-card__color--grey-tint1: #c6c4c6;
@@ -8,7 +7,6 @@ $alphaville-card__color--grey-tint3: #443c47;
 $alphaville-card__color--yellow-tint1: #fffce9;
 $alphaville-card__color--yellow-tint2: #f4a208;
 $alphaville-card__color--yellow-tint3: #b35400;
-
 
 @mixin truncate ($lineHeight, $lines, $ellipsis: true) {
 	max-height: $lineHeight * $lines;
@@ -24,14 +22,14 @@ $alphaville-card__color--yellow-tint3: #b35400;
 }
 
 .alphaville-card__heading {
-	@include oTeaserHeading;
-	@include oTypographySize(4);
+	@include oTeaserHeading();
+	@include oTypographyDisplay($scale: 4);
 	margin-bottom: 10px;
 }
 
 .alphaville-card__heading--invert {
-	@include oTeaserHeading;
-	color: oColorsGetPaletteColor('black-80');
+	@include oTeaserHeading();
+	color: oColorsByName('black-80');
 }
 
 .alphaville-card__heading-truncate--2lines {
@@ -43,14 +41,13 @@ $alphaville-card__color--yellow-tint3: #b35400;
 }
 
 .alphaville-card__tag {
-	@include oTeaserTag;
-	@include oTeaserMeta;
+	@include oEditorialTypographyTag(null);
 	margin: 0 0 10px;
 	display: inline-block;
 }
 
 .alphaville-card__standfirst {
-	@include oTeaserStandfirst;
+	@include oEditorialTypographyStandfirst();
 }
 
 .alphaville-card__standfirst-truncate--2lines {
@@ -74,14 +71,19 @@ $alphaville-card__color--yellow-tint3: #b35400;
 }
 
 .alphaville-card__timestamp {
-	@include oTeaserTimestamp;
-	display:inline-block;
+	@include oEditorialTypographyTimestamp();
+	display: inline-block;
 }
 
 
 .alphaville-card {
-	@include oTeaserBase;
+	@include oTypographySans(-1);
+	position: relative;
+	width: 100%;
+	text-rendering: optimizeLegibility;
+	margin-bottom: oSpacingByName('s4');
 	padding: 10px 10px 0;
+	box-sizing: border-box;
 
 	$comment-counter-color: #22757c;
 	.alphaville-card--comment-counter {
@@ -93,7 +95,11 @@ $alphaville-card__color--yellow-tint3: #b35400;
 		padding: 9px 0 0 5px;
 
 		&:after {
-			@include oIconsGetIcon('speech', $comment-counter-color, 24);
+			@include oIconsContent(
+				$icon-name: 'speech',
+				$color: $comment-counter-color,
+				$size: 24
+			);
 			content: '';
 			position: relative;
 			vertical-align: middle;
@@ -102,7 +108,7 @@ $alphaville-card__color--yellow-tint3: #b35400;
 
 	&.alphaville-card--grid {
 		overflow: hidden;
-		background-color: oColorsGetPaletteColor('white-60');
+		background-color: oColorsByName('white-60');
 
 		p {
 			margin: 0;
@@ -134,10 +140,9 @@ $alphaville-card__color--yellow-tint3: #b35400;
 			line-height: 25.2px;
 		}
 
-
 		.alphaville-card__image {
-			@include oTeaserImage;
-
+			display: block;
+			margin: 0;
 			width: 100%;
 
 			img {
@@ -170,12 +175,12 @@ $alphaville-card__color--yellow-tint3: #b35400;
 	p.article__byline {
 		display: inline-block;
 		font-family: MetricWeb, sans-serif;
-		color:#333333;
+		color: #333333;
 		line-height: 12px;
 		font-size: 12px;
 		.article__byline-tag {
 			font-family: MetricWeb, sans-serif;
-			color:#9e2f50;
+			color: oColorsByName('claret');
 			font-weight: 600;
 			line-height: 12px;
 			font-size: 12px;
@@ -226,7 +231,11 @@ $alphaville-card__color--yellow-tint3: #b35400;
 			padding-right: 25px;
 
 			&:after {
-				@include oIconsGetIcon('series', oColorsGetPaletteColor('black-50'), 40, $iconset-version: 1);
+				@include oIconsContent(
+					$icon-name: 'series',
+					$color: oColorsByName('black-50'),
+					$size: 40
+				);
 				content: '';
 				position: absolute;
 				top: 0;
@@ -246,7 +255,11 @@ $alphaville-card__color--yellow-tint3: #b35400;
 			padding-right: 50px;
 
 			&:before {
-				@include oIconsGetIcon('podcast', oColorsGetPaletteColor('black-50'), 40, $iconset-version: 1);
+				@include oIconsContent(
+					$icon-name: 'podcast',
+					$color: oColorsByName('black-50'),
+					$size: 40
+				);
 				content: '';
 				position: absolute;
 				top: 0;
@@ -285,8 +298,8 @@ $alphaville-card__color--yellow-tint3: #b35400;
 	.alphaville-card--marketslive-live--lozenge {
 		@include marketslive-lozenge-icon(
 			$size: 120,
-			$color: $alphaville-card__color--grey-tint2);
-
+			$color: $alphaville-card__color--grey-tint2
+		);
 		position: absolute;
 		top: -55px;
 		right: -60px;
@@ -295,7 +308,8 @@ $alphaville-card__color--yellow-tint3: #b35400;
 	.alphaville-card--marketslive-lozenge-icon {
 		@include marketslive-lozenge-icon(
 			$size: 18,
-			$bgColor: oColorsGetPaletteColor('paper'));
+			$bgColor: oColorsByName('paper')
+		);
 		margin-bottom: -2px;
 	}
 
@@ -348,7 +362,11 @@ $alphaville-card__color--yellow-tint3: #b35400;
 			color: $alphaville-card__color--yellow-tint1;
 
 			&:after {
-				@include oIconsGetIcon('speech', $alphaville-card__color--yellow-tint1, 24);
+				@include oIconsContent(
+					$icon-name: 'speech',
+					$color: $alphaville-card__color--yellow-tint1,
+					$size: 24
+				);
 				position: relative;
 				vertical-align: middle;
 			}
@@ -357,7 +375,7 @@ $alphaville-card__color--yellow-tint3: #b35400;
 
 	&.alphaville-card--marketslive-live {
 		.alphaville-card__theme-part2 {
-			color: oColorsGetPaletteColor('white');
+			color: oColorsByName('white');
 			font-weight: 600;
 		}
 	}
@@ -395,12 +413,12 @@ $alphaville-card__color--yellow-tint3: #b35400;
 	}
 
 	.alphaville-card__subheading {
-		@include oTeaserHeading;
-		@include oTypographySansBold($scale: -2);
+		@include oTeaserHeading();
+		@include oTypographySans($scale: -2, $weight: 'semibold');
 
 		&,
 		a {
-			color: oColorsGetPaletteColor('black-30');
+			color: oColorsByName('black-30');
 		}
 	}
 }
@@ -424,7 +442,7 @@ $alphaville-card__color--yellow-tint3: #b35400;
 	position: relative;
 
 	.alphaville-card__heading {
-		@include oTypographySansBold($scale: 2);
+		@include oTypographySans($scale: 2, $weight: 'semibold');
 		font-size: 25px;
 		line-height: 26px;
 		margin-bottom: 10px;
@@ -441,7 +459,7 @@ $alphaville-card__color--yellow-tint3: #b35400;
 		&,
 		a,
 		.alphaville-card__tag {
-			@include oTypographySansBold($scale: 4);
+			@include oTypographySans($scale: 4, $weight: 'semibold');
 			font-size: 25px;
 			line-height: 26px;
 			text-transform: uppercase;
@@ -483,7 +501,7 @@ $alphaville-card__color--yellow-tint3: #b35400;
 	position: relative;
 
 	.alphaville-card__heading {
-		@include oTypographySansBold($scale: 4);
+		@include oTypographySans($scale: 4, $weight: 'semibold');
 		line-height: 26px;
 		font-size: 25px;
 		margin-bottom: 12px;
@@ -555,7 +573,11 @@ $alphaville-card__color--yellow-tint3: #b35400;
 		color: $alphaville-card__color--yellow-tint1;
 
 		&:after {
-			@include oIconsGetIcon('speech', $alphaville-card__color--yellow-tint1, 24);
+			@include oIconsContent(
+				$icon-name: 'speech',
+				$color: $alphaville-card__color--yellow-tint1,
+				$size: 24
+			);
 			position: relative;
 			vertical-align: middle;
 		}
@@ -569,7 +591,7 @@ $alphaville-card__color--yellow-tint3: #b35400;
 	min-height: 170px;
 
 	.alphaville-card__heading {
-		@include oTypographySansBold($scale: 4);
+		@include oTypographySans($scale: 4, $weight: 'semibold');
 		line-height: 26px;
 		font-size: 25px;
 		margin-bottom: 12px;
@@ -621,7 +643,11 @@ $alphaville-card__color--yellow-tint3: #b35400;
 		color: $alphaville-card__color--yellow-tint1;
 
 		&:after {
-			@include oIconsGetIcon('speech', $alphaville-card__color--yellow-tint1, 24);
+			@include oIconsContent(
+				$icon-name: 'speech',
+				$color: $alphaville-card__color--yellow-tint1,
+				$size: 24
+			);
 			position: relative;
 			vertical-align: middle;
 		}

--- a/content-box/main.scss
+++ b/content-box/main.scss
@@ -1,5 +1,5 @@
-$border-color: oColorsGetPaletteColor('black-20');
-$bg-color: oColorsGetPaletteColor('paper');
+$border-color: oColorsByName('black-20');
+$bg-color: oColorsByName('paper');
 
 .alphaville-content-box {
 	position: relative;

--- a/cookie-banner/main.scss
+++ b/cookie-banner/main.scss
@@ -1,2 +1,2 @@
-$o-cookie-message-is-silent: false;
 @import 'o-cookie-message/main';
+@include oCookieMessage();

--- a/generic/main.scss
+++ b/generic/main.scss
@@ -1,9 +1,9 @@
 html {
 	// The iconic pink background
-	@include oColorsFor(page, background);
+	background: oColorsByUsecase('page', 'background');
 
 	// Set a font family on the whole document
-	font-family: $o-typography-sans;
+	@include oTypographySans();
 	font-size: initial;
 
 	// Prevent navigation menus from creating
@@ -13,7 +13,7 @@ html {
 
 body {
 	margin: 0;
-	color: oColorsGetPaletteColor('black-80');
+	color: oColorsByName('black-80');
 	-webkit-text-size-adjust: 100%;
 }
 
@@ -23,7 +23,7 @@ body {
 }
 
 a {
-	color: oColorsGetPaletteColor('oxford');
+	color: oColorsByName('oxford');
 	-webkit-font-smoothing: antialiased;
 	text-decoration: none;
 

--- a/header/main.handlebars
+++ b/header/main.handlebars
@@ -65,11 +65,11 @@
 	</div>
 
 	<nav id="o-header-nav-mobile" class="o-header__row o-header__nav o-header__nav--mobile" role="navigation" data-trackable="header-nav:mobile">
-		<div class="o-header__container">			
+		<div class="o-header__container">
 			<ul class="o-header__nav-list o-header__nav-list--left" data-trackable="primary-nav">
 				{{#mobileNavItems}}
 				<li class="o-header__nav-item {{liClass}}">
-					<a class="o-header__nav-link o-header__nav-link--primary {{#lozenge}}alphaville-header-ml-title{{/lozenge}}" href="{{url}}" {{#selected}}aria-selected="true"{{/selected}} {{{attributes}}} data-trackable="mega-menu-link">
+					<a class="o-header__nav-link o-header__nav-link--primary {{#lozenge}}alphaville-header-ml-title{{/lozenge}}" href="{{url}}" {{#selected}}aria-current="page"{{/selected}} {{{attributes}}} data-trackable="mega-menu-link">
 						{{{name}}}
 						{{#lozenge}}<span class="alphaville-header-ml-lozenge-icon"></span>{{/lozenge}}
 					</a>
@@ -103,7 +103,7 @@
 			<ul class="o-header__nav-list o-header__nav-list--left" data-trackable="primary-nav">
 				{{#navItems}}
 				<li class="o-header__nav-item {{liClass}}">
-					<a class="o-header__nav-link o-header__nav-link--primary {{#lozenge}}alphaville-header-ml-title{{/lozenge}}" href="{{url}}" {{#selected}}aria-selected="true"{{/selected}} id="o-header-link-" data-trackable="link">
+					<a class="o-header__nav-link o-header__nav-link--primary {{#lozenge}}alphaville-header-ml-title{{/lozenge}}" href="{{url}}" {{#selected}}aria-current="page"{{/selected}} id="o-header-link-" data-trackable="link">
 						{{{name}}}
 						{{#lozenge}}<span class="alphaville-header-ml-lozenge-icon"></span>{{/lozenge}}
 					</a>
@@ -165,7 +165,7 @@
 								<ul class="o-header__nav-list" data-trackable="primary-nav">
 									{{#navItems}}
 									<li class="o-header__nav-item {{liClass}}">
-										<a class="o-header__nav-link o-header__nav-link--primary {{#lozenge}}alphaville-header-ml-title{{/lozenge}}" href="{{url}}" {{#selected}}aria-selected="true"{{/selected}} id="o-header-link-" data-trackable="link">
+										<a class="o-header__nav-link o-header__nav-link--primary {{#lozenge}}alphaville-header-ml-title{{/lozenge}}" href="{{url}}" {{#selected}}aria-current="page"{{/selected}} id="o-header-link-" data-trackable="link">
 											{{{name}}}
 											{{#lozenge}}<span class="alphaville-header-ml-lozenge-icon"></span>{{/lozenge}}
 										</a>

--- a/header/main.scss
+++ b/header/main.scss
@@ -27,7 +27,7 @@
 	display: none;
 
 	.o-header__drawer-menu-link--selected & {
-		@include marketslive-lozenge-icon($color: oColorsGetPaletteColor('white'));
+		@include marketslive-lozenge-icon($color: oColorsByName('white'));
 		display: none;
 
 		.ml-is-live & {
@@ -49,7 +49,7 @@
 		@include marketslive-live-title();
 
 		&.o-header__drawer-menu-link--selected {
-			@include marketslive-live-title($color: oColorsGetPaletteColor('white'));
+			@include marketslive-live-title($color: oColorsByName('white'));
 		}
 	}
 }
@@ -79,7 +79,7 @@
 	width: 1px;
 	height: 23px;
 	margin: 0 5px;
-	background: oColorsGetPaletteColor('black-20');
+	background: oColorsByName('black-20');
 }
 
 .alphaville-header__toggle-article-view-item {
@@ -106,36 +106,42 @@
 	}
 }
 
-$alphaville-header__toggle-article-view--color-normal: oColorsGetPaletteColor('black-20');
-$alphaville-header__toggle-article-view--color-active: oColorsGetPaletteColor('teal-40');
+$alphaville-header__toggle-article-view--color-normal: oColorsByName('black-20');
+$alphaville-header__toggle-article-view--color-active: oColorsByName('teal-40');
 
-.alphaville-header__toggle-article-view--grid {
-	@include oIconsGetIcon('grid', $alphaville-header__toggle-article-view--color-normal, 25, $iconset-version: 1);
+@mixin _header-icon ($name) {
+	@include oIconsContent(
+		$icon-name: $name,
+		$color: $alphaville-header__toggle-article-view--color-normal,
+		$size: 25
+	);
 
 	&:after {
-		@include oIconsGetIcon('grid', $alphaville-header__toggle-article-view--color-active, 25, $iconset-version: 1);
+		@include oIconsContent(
+			$icon-name: $name,
+			$color: $alphaville-header__toggle-article-view--color-active,
+			$size: 25
+		);
 		visibility: hidden;
 		left: -9999px;
 	}
 
 	&:hover,
 	&[data-selected] {
-		@include oIconsGetIcon('grid', $alphaville-header__toggle-article-view--color-active, 25, $iconset-version: 1);
+		@include oIconsContent(
+			$icon-name: $name,
+			$color: $alphaville-header__toggle-article-view--color-active,
+			$size: 25
+		);
 	}
 }
+
+.alphaville-header__toggle-article-view--grid {
+	@include _header-icon(grid);
+}
+
 .alphaville-header__toggle-article-view--list {
-	@include oIconsGetIcon('list', $alphaville-header__toggle-article-view--color-normal, 25, $iconset-version: 1);
-
-	&:after {
-		@include oIconsGetIcon('list', $alphaville-header__toggle-article-view--color-active, 25, $iconset-version: 1);
-		visibility: hidden;
-		left: -9999px;
-	}
-
-	&:hover,
-	&[data-selected] {
-		@include oIconsGetIcon('list', $alphaville-header__toggle-article-view--color-active, 25, $iconset-version: 1);
-	}
+	@include _header-icon(list);
 }
 
 .alphaville-header__container {
@@ -188,7 +194,7 @@ $alphaville-header__toggle-article-view--color-active: oColorsGetPaletteColor('t
 
 .alphaville-header__subbrand-title {
 	@include oTypographySans($scale: 4);
-	color: oColorsGetPaletteColor('white');
+	color: oColorsByName('white');
 	text-transform: uppercase;
 	font-weight: 500;
 	display: inline-block;

--- a/infinite-scroll/main.js
+++ b/infinite-scroll/main.js
@@ -1,4 +1,4 @@
-const oViewport = require('o-viewport').default;
+import oViewport from 'o-viewport';
 const httpRequest = require('../utils/httpRequest');
 const domUtils = require('../utils/dom');
 

--- a/infinite-scroll/main.js
+++ b/infinite-scroll/main.js
@@ -1,4 +1,4 @@
-const oViewport = require('o-viewport');
+const oViewport = require('o-viewport').default;
 const httpRequest = require('../utils/httpRequest');
 const domUtils = require('../utils/dom');
 

--- a/main.js
+++ b/main.js
@@ -1,12 +1,22 @@
-exports['o-date'] = require('o-date').default;
-exports['o-ads'] = require('o-ads').default;
-exports['o-grid'] = require('o-grid').default;
-exports['o-header'] = require('o-header').default;
-exports['o-footer'] = require('o-footer').default;
-exports['o-tracking'] = require('o-tracking').default;
-exports['o-overlay'] = require('o-overlay').default;
-exports['o-share'] = require('o-share').default;
-exports['o-cookie-message'] = require('o-cookie-message').default;
+import oDate from 'o-date';
+import oAds from 'o-ads';
+import oGrid from 'o-grid';
+import oHeader from 'o-header';
+import oFooter from 'o-footer';
+import oTracking from 'o-tracking';
+import oOverlay from 'o-overlay';
+import oShare from 'o-share';
+import oCookieMessage from 'o-cookie-message';
+
+exports['o-date'] = oDate;
+exports['o-ads'] = oAds;
+exports['o-grid'] = oGrid;
+exports['o-header'] = oHeader;
+exports['o-footer'] = oFooter;
+exports['o-tracking'] = oTracking;
+exports['o-overlay'] = oOverlay;
+exports['o-share'] = oShare;
+exports['o-cookie-message'] = oCookieMessage;
 
 exports['header'] = require('./header/main');
 exports['marketslive-session-listener'] = require('./marketslive-session-listener/main');

--- a/main.js
+++ b/main.js
@@ -1,12 +1,12 @@
-exports['o-date'] = require('o-date');
-exports['o-ads'] = require('o-ads');
-exports['o-grid'] = require('o-grid');
-exports['o-header'] = require('o-header');
-exports['o-footer'] = require('o-footer');
-exports['o-tracking'] = require('o-tracking');
-exports['o-overlay'] = require('o-overlay');
-exports['o-share'] = require('o-share');
-exports['o-cookie-message'] = require('o-cookie-message');
+exports['o-date'] = require('o-date').default;
+exports['o-ads'] = require('o-ads').default;
+exports['o-grid'] = require('o-grid').default;
+exports['o-header'] = require('o-header').default;
+exports['o-footer'] = require('o-footer').default;
+exports['o-tracking'] = require('o-tracking').default;
+exports['o-overlay'] = require('o-overlay').default;
+exports['o-share'] = require('o-share').default;
+exports['o-cookie-message'] = require('o-cookie-message').default;
 
 exports['header'] = require('./header/main');
 exports['marketslive-session-listener'] = require('./marketslive-session-listener/main');

--- a/main.scss
+++ b/main.scss
@@ -1,3 +1,5 @@
+$system-code: 'ftalphaville';
+
 img {
 	border: 0;
 }
@@ -20,40 +22,42 @@ img {
 $o-ads-is-silent: false;
 @import 'o-ads/main';
 
-$o-fonts-is-silent: false;
 @import 'o-fonts/main';
+@include oFonts();
 
-$o-typography-is-silent: false;
 @import 'o-typography/main';
+@include oTypography();
 
 $o-grid-mode: snappy;
-$o-grid-is-silent: false;
 @import 'o-grid/main';
+@include oGrid();
 
-$o-buttons-is-silent: false;
 @import 'o-buttons/main';
+@include oButtons();
 
-$o-header-is-silent: false;
 @import 'o-header/main';
+@include oHeader();
 
-$o-footer-is-silent: false;
 @import 'o-footer/main';
+@include oFooter();
 
-$o-icons-is-silent: false;
 @import 'o-icons/main';
+@include oIcons();
 
-$o-overlay-is-silent: false;
 @import 'o-overlay/main';
+@include oOverlay();
 
-$o-forms-is-silent: false;
 @import 'o-forms/main';
+@include oForms();
 
-$o-teaser-is-silent: false;
 @import 'o-teaser/main';
+@include oTeaser();
+
+@import 'o-editorial-typography/main';
 
 @import 'o-colors/main';
 
-@import "o-share/main";
+@import 'o-share/main';
 
 @import './generic/main';
 

--- a/marketslive-session-notification/main.scss
+++ b/marketslive-session-notification/main.scss
@@ -6,7 +6,7 @@ $ml-notification-background-color: transparent;
 
 	display: inline-block;
 	padding: #{round($size / 2 - $borderWidth)}px;
-	color: oColorsGetPaletteColor("white");
+	color: oColorsByName("white");
 	background-color: $bgColor;
 	border-radius: #{(2 * $size)}px;
 	margin-left: 5px;
@@ -47,7 +47,7 @@ $ml-notification-background-color: transparent;
 	bottom: 0;
 	left: 0px;
 	width: 100%;
-	background: oColorsGetPaletteColor("white");
+	background: oColorsByName("white");
 	padding: 6px 0;
 	box-shadow: 0px -2px 4px -2px rgba(0, 0, 0, 0.3);
 	z-index: 5;
@@ -63,7 +63,11 @@ $ml-notification-background-color: transparent;
 	}
 
 	.marketslive-notification-close {
-		@include oIconsGetIcon(cross, oColorsGetPaletteColor("teal-80"), 15);
+		@include oIconsContent(
+			$icon-name: cross,
+			$color: oColorsByName("teal-80"),
+			$size: 15
+		);
 		float: right;
 		margin-right: 10px;
 		cursor: pointer;
@@ -120,8 +124,8 @@ $ml-notification-background-color: transparent;
 		a {
 			display: inline-block;
 			padding: 3px 7px;
-			border: 1px solid oColorsGetPaletteColor("teal-80");
-			color: oColorsGetPaletteColor("teal-80");
+			border: 1px solid oColorsByName("teal-80");
+			color: oColorsByName("teal-80");
 			font-size: 13px;
 			text-decoration: none;
 

--- a/overlays/AlertOverlay.js
+++ b/overlays/AlertOverlay.js
@@ -1,5 +1,5 @@
-const Overlay = require('o-overlay');
-const Delegate = require('ftdomdelegate');
+import Overlay from 'o-overlay';
+import Delegate from 'ftdomdelegate';
 
 function AlertOverlay (title, text) {
 	if (!text) {

--- a/overlays/ConfirmOverlay.js
+++ b/overlays/ConfirmOverlay.js
@@ -1,5 +1,5 @@
-const Overlay = require('o-overlay');
-const Delegate = require('ftdomdelegate');
+import Overlay from 'o-overlay';
+import Delegate from 'ftdomdelegate';
 
 function ConfirmOverlay (title, text) {
 	if (!text) {

--- a/overlays/ConfirmOverlay.js
+++ b/overlays/ConfirmOverlay.js
@@ -13,7 +13,7 @@ function ConfirmOverlay (title, text) {
 				<div class="alphaville-overlay-text">${text}</div>
 				<div class="alphaville-overlay-buttons">
 					<button type="button" class="alphaville-overlay-ok o-buttons o-buttons--primary">OK</button>
-					<button type="button" class="alphaville-overlay-cancel o-buttons">Cancel</button>
+					<button type="button" class="alphaville-overlay-cancel o-buttons o-buttons--secondary">Cancel</button>
 				</div>
 			`,
 			modal: true,

--- a/overlays/FormOverlay.js
+++ b/overlays/FormOverlay.js
@@ -1,5 +1,5 @@
-const Overlay = require('o-overlay');
-const Delegate = require('ftdomdelegate');
+import Overlay from 'o-overlay';
+import Delegate from 'ftdomdelegate';
 
 function serialize (form) {
 	const s = {};

--- a/overlays/FormOverlay.js
+++ b/overlays/FormOverlay.js
@@ -77,7 +77,7 @@ function FormOverlay (options) {
 					<div class="alphaville-overlay-form-content">${generateFormHtml(fields)}</div>
 					<div class="alphaville-overlay-buttons">
 						${submitLabel ? `<button type="submit" class="alphaville-overlay-submit o-buttons o-buttons--primary">${submitLabel}</button>` : ''}
-						<button type="button" class="alphaville-overlay-cancel o-buttons">${submitLabel ? 'Cancel' : 'Close'}</button>
+						<button type="button" class="alphaville-overlay-cancel o-buttons o-buttons--secondary">${submitLabel ? 'Cancel' : 'Close'}</button>
 					</div>
 				</form>
 			`,

--- a/pagination/main.handlebars
+++ b/pagination/main.handlebars
@@ -1,11 +1,11 @@
 <div class="alphaville-pagination" data-trackable="pagination">
 	{{#left}}
-		<a href="{{../baseUrl}}page={{page}}" class="o-buttons o-buttons-icon o-buttons-icon--arrow-left o-buttons-icon--icon-only" data-trackable="link">
+		<a href="{{../baseUrl}}page={{page}}" class="o-buttons o-buttons--secondary o-buttons-icon o-buttons-icon--arrow-left o-buttons-icon--icon-only" data-trackable="link">
 			<span class="o-buttons-icon__label">Newer results</span>
 		</a>
 	{{/left}}
 	{{^left}}
-		<button class="o-buttons o-buttons-icon o-buttons-icon--arrow-left o-buttons-icon--icon-only" disabled data-trackable="link">
+		<button class="o-buttons o-buttons--secondary o-buttons-icon o-buttons-icon--arrow-left o-buttons-icon--icon-only" disabled data-trackable="link">
 			<span class="o-buttons-icon__label">Newer results</span>
 		</button>
 	{{/left}}
@@ -13,12 +13,12 @@
 	<span class="alphaville-pagination-label">You are on page <strong>{{currentPage}}</strong></span>
 
 	{{#right}}
-		<a href="{{../baseUrl}}page={{page}}" class="o-buttons o-buttons-icon o-buttons-icon--arrow-right o-buttons-icon--icon-only" data-trackable="link">
+		<a href="{{../baseUrl}}page={{page}}" class="o-buttons o-buttons--secondary o-buttons-icon o-buttons-icon--arrow-right o-buttons-icon--icon-only" data-trackable="link">
 			<span class="o-buttons-icon__label">Older results</span>
 		</a>
 	{{/right}}
 	{{^right}}
-		<button class="o-buttons o-buttons-icon o-buttons-icon--arrow-right o-buttons-icon--icon-only" disabled data-trackable="link">
+		<button class="o-buttons o-buttons--secondary o-buttons-icon o-buttons-icon--arrow-right o-buttons-icon--icon-only" disabled data-trackable="link">
 			<span class="o-buttons-icon__label">Older results</span>
 		</button>
 	{{/right}}

--- a/share/main.scss
+++ b/share/main.scss
@@ -1,19 +1,14 @@
-@include oShareBase(o-share);
-@include oShareActionIcon(facebook, o-share);
-@include oShareActionIcon(twitter, o-share);
-@include oShareActionIcon(whatsapp, o-share);
-@include oShareActionIcon(linkedin, o-share);
-@include oShareActionIcon(mail, o-share);
+@include oShare($opts: ('vertical': false));
 
 .article__share {
 	position: relative;
 	margin-top: 15px;
 	padding: 5px 0;
-	border-top: 1px solid oColorsGetPaletteColor('black-20');
-	border-bottom: 1px solid oColorsGetPaletteColor('black-20');
+	border-top: 1px solid oColorsByName('black-20');
+	border-bottom: 1px solid oColorsByName('black-20');
 
 	a {
-		@include oColorsFor(link, text);
+		color: oColorsByUsecase('link', 'text');
 		text-decoration: none;
 	}
 
@@ -32,7 +27,11 @@
 		@include oTypographySans($scale: 0);
 
 		&:before {
-			@include oIconsGetIcon('speech', oColorsGetPaletteColor('black-70'), 40);
+			@include oIconsContent(
+				$icon-name: speech,
+				$color: oColorsByName('black-70'),
+				$size: 40
+			);
 			content: '';
 			position: relative;
 			vertical-align: middle;
@@ -47,7 +46,11 @@
 		}
 
 		&:before {
-			@include oIconsGetIcon('print', oColorsGetPaletteColor('black-70'), 40);
+			@include oIconsContent(
+				$icon-name: print,
+				$color: oColorsByName('black-70'),
+				$size: 40
+			);
 			content: '';
 			position: relative;
 			vertical-align: middle;

--- a/spinner/main.scss
+++ b/spinner/main.scss
@@ -7,7 +7,7 @@
 	}
 }
 
-@mixin alphaville-spinner ($color: oColorsGetPaletteColor('black-40'), $bgColor: oColorsGetPaletteColor('paper'), $size: 40px, $speed: 0.7s) {
+@mixin alphaville-spinner ($color: oColorsByName('black-40'), $bgColor: oColorsByName('paper'), $size: 40px, $speed: 0.7s) {
 	font-size: 10px;
 	text-indent: -9999em;
 	width: $size;
@@ -35,5 +35,5 @@
 }
 
 .alphaville-spinner {
-	@include alphaville-spinner($size: 30px, $color: oColorsGetPaletteColor('black-10'));
+	@include alphaville-spinner($size: 30px, $color: oColorsByName('black-10'));
 }

--- a/tracking/main.js
+++ b/tracking/main.js
@@ -1,4 +1,5 @@
-const oTracking = require('o-tracking');
+const oTracking = require('o-tracking').default;
+
 function otrackinginit() {
 	const config_data = {
 		server: 'https://spoor-api.ft.com/px.gif',

--- a/tracking/main.js
+++ b/tracking/main.js
@@ -1,4 +1,4 @@
-const oTracking = require('o-tracking').default;
+import oTracking from 'o-tracking';
 
 function otrackinginit() {
 	const config_data = {


### PR DESCRIPTION
There are a lot of changes here, but it's part of a single action: upgrading all
of the packages to their latest versions as part of the Origami major
cascade. Every function call and mixin use has been migrated to the latest
version, most of it is quite small.

The main place of interest is `card/main.scss` which heavily used some
`o-teaser` mixins that have since been removed. I've chosen to copy over the css
that was in the mixin before it was removed, but it's possible it would be a
better idea to update the templates to use `o-teaser` classes instead (seeing as
this component has always output the whole `o-teaser` css too)

In general if anyone gets some time it might be a good idea to check if the
outputting of all of the css rules for so many of the origami dependencies is
something alphaville apps actually need