### PR TITLE
DO NOT MERGE: Remove comments split service logic

### DIFF
--- a/share/main.handlebars
+++ b/share/main.handlebars
@@ -20,24 +20,13 @@
 
 		{{#article.comments.enabled}}
 			{{^hideCommentCount}}
-				{{#if useCoralTalk}}
-					<a href="#comments"
-						class="o-comments article__share__comments article__share-item"
-						data-o-component="o-comments"
-						data-o-comments-article-id="{{article.id}}"
-						data-o-comments-count="true"
-						data-trackable="comment-count">
-					</a>
-				{{else}}
-					<a href="#comments"
-						class="article__share__comments article__share-item"
-						data-o-component="o-comments"
-						data-o-comments-count
-						data-o-comments-config-article-id="{{article.id}}"
-						data-o-comments-config-template="{count}"
-						data-trackable="comment-count">
-					</a>
-				{{/if}}
+                <a href="#comments"
+                    class="o-comments article__share__comments article__share-item"
+                    data-o-component="o-comments"
+                    data-o-comments-article-id="{{article.id}}"
+                    data-o-comments-count="true"
+                    data-trackable="comment-count">
+                </a>
 			{{/hideCommentCount}}
 		{{/article.comments.enabled}}
 	</div>


### PR DESCRIPTION
Display Coral Talk count for all articles.

**This should be merged after comments migration is complete.**