### PR TITLE
Change MBA ranking link in footer

### DIFF
--- a/footer/main.handlebars
+++ b/footer/main.handlebars
@@ -62,7 +62,7 @@
 													<a class="o-footer__matrix-link" href="http://markets.ft.com/data/portfolio/dashboard" data-trackable="Portfolio">Portfolio</a>
 													<a class="o-footer__matrix-link" href="http://www.ft.com/uk-edition" data-trackable="ePaper">ePaper</a>
 													<a class="o-footer__matrix-link" href="http://markets.ft.com/data/alerts/" data-trackable="Alerts Hub">Alerts Hub</a>
-													<a class="o-footer__matrix-link" href="http://rankings.ft.com/businessschoolrankings/global-mba-ranking-2016?ft_site=falcon" data-trackable="MBA Rankings">MBA Rankings</a>
+													<a class="o-footer__matrix-link" href="http://rankings.ft.com/" data-trackable="MBA Rankings">MBA Rankings</a>
 											</div>
 											<div class="o-footer__matrix-column">
 


### PR DESCRIPTION
The **MBA Rankings** in the footer links of https://ftalphaville.ft.com/ links to 2016 MBA ranking (http://rankings.ft.com/businessschoolrankings/global-mba-ranking-2016?ft_site=falcon)

We need to change it to the most futureproof URL

[Ops Cops ticket](https://financialtimes.atlassian.net/browse/NOPS-152)
