### PR TITLE
Fix missing share icons

### DIFF
--- a/share/main.scss
+++ b/share/main.scss
@@ -1,4 +1,7 @@
-@include oShare($opts: ('vertical': false));
+@include oShare($opts: (
+	'vertical': false,
+	'icons': ('twitter', 'facebook', 'linkedin')
+));
 
 .article__share {
 	position: relative;


### PR DESCRIPTION
[NOPS-169](https://financialtimes.atlassian.net/browse/NOPS-169)

Before
<img width="729" alt="Screenshot 2020-05-15 at 09 38 14" src="https://user-images.githubusercontent.com/21194161/82067637-e6524b80-96c8-11ea-997f-6c26a05042f7.png">

After
<img width="730" alt="Screenshot 2020-05-15 at 16 25 25" src="https://user-images.githubusercontent.com/21194161/82067675-f4a06780-96c8-11ea-91de-5ad8f99d319a.png">
