### PR TITLE
Update CODEOWNERS

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,2 +1,2 @@
 # Guessed from System and Package relationships in Biz Ops
-* @Financial-Times/content-innovation
+* @Financial-Times/storytelling


### PR DESCRIPTION
As part of the Storytelling Team name change ([ticket](https://financialtimes.atlassian.net/browse/CI-1318)), The Github team name is updated to storytelling and [all the projects](https://biz-ops.in.ft.com/GithubTeam/Financial-Times%2Fcontent-innovation#general) with CODEOWNERS must to be updated.